### PR TITLE
Env var map needs to be built at runtime, not at compile time.

### DIFF
--- a/src/tech/config/core.clj
+++ b/src/tech/config/core.clj
@@ -122,15 +122,15 @@
 (defn- build-config
   "Squashes the environment onto the config-*.edn files."
   ([config-map]
-   (let [env (read-env)]
-     (let [final-map (coercing-merge config-map env)
-           print-map (->> final-map
-                          (filter #(*config-keys* (first %)))
-                          (into {}))]
-       (doseq [k (set/intersection (set (keys env))
-                                   (set (keys print-map)))]
-         (alter-var-root #'*config-sources* #(assoc % k "environment")))
-       final-map)))
+   (let [env (read-env)
+         final-map (coercing-merge config-map env)
+         print-map (->> final-map
+                        (filter #(*config-keys* (first %)))
+                        (into {}))]
+     (doseq [k (set/intersection (set (keys env))
+                                 (set (keys print-map)))]
+       (alter-var-root #'*config-sources* #(assoc % k "environment")))
+     final-map))
   ([]
    (build-config (file-config))))
 

--- a/src/tech/config/core.clj
+++ b/src/tech/config/core.clj
@@ -1,5 +1,5 @@
 (ns tech.config.core
-  (:require [environ.core :refer [env]]
+  (:require [tech.config.environ :refer [read-env]]
             [clojure.java.classpath :as cp]
             [clojure.set :as set]
             [clojure.edn :as edn]
@@ -122,14 +122,15 @@
 (defn- build-config
   "Squashes the environment onto the config-*.edn files."
   ([config-map]
-   (let [final-map (coercing-merge config-map env)
-         print-map (->> final-map
-                        (filter #(*config-keys* (first %)))
-                        (into {}))]
-     (doseq [k (set/intersection (set (keys env))
-                                 (set (keys print-map)))]
-       (alter-var-root #'*config-sources* #(assoc % k "environment")))
-     final-map))
+   (let [env (read-env)]
+     (let [final-map (coercing-merge config-map env)
+           print-map (->> final-map
+                          (filter #(*config-keys* (first %)))
+                          (into {}))]
+       (doseq [k (set/intersection (set (keys env))
+                                   (set (keys print-map)))]
+         (alter-var-root #'*config-sources* #(assoc % k "environment")))
+       final-map)))
   ([]
    (build-config (file-config))))
 

--- a/src/tech/config/environ.cljc
+++ b/src/tech/config/environ.cljc
@@ -1,0 +1,80 @@
+(ns tech.config.environ
+  "Copy of environ that exposes 'read-env'"
+  (:require #?(:clj [clojure.edn :as edn] :cljs [cljs.reader :as edn])
+            #?(:clj [clojure.java.io :as io])
+            #?(:cljs [goog.object :as obj])
+            [clojure.string :as str]))
+
+
+#?(:cljs (def ^:private nodejs?
+           (exists? js/require)))
+
+#?(:cljs (def ^:private fs
+           (when nodejs? (js/require "fs"))))
+
+#?(:cljs (def ^:private process
+           (when nodejs? (js/require "process"))))
+
+(defn- keywordize [s]
+  (-> (str/lower-case s)
+      (str/replace "_" "-")
+      (str/replace "." "-")
+      (keyword)))
+
+(defn- sanitize-key [k]
+  (let [s (keywordize (name k))]
+    (if-not (= k s) (println "Warning: environ key" k "has been corrected to" s))
+    s))
+
+(defn- sanitize-val [k v]
+  (if (string? v)
+    v
+    (do (println "Warning: environ value" (pr-str v) "for key" k "has been cast to string")
+        (str v))))
+
+(defn- read-system-env []
+  (->> #?(:clj (System/getenv)
+          :cljs (zipmap (obj/getKeys (.-env process))
+                        (obj/getValues (.-env process))))
+       (map (fn [[k v]] [(keywordize k) v]))
+       (into {})))
+
+#?(:clj (defn- read-system-props []
+          (->> (System/getProperties)
+               (map (fn [[k v]] [(keywordize k) v]))
+               (into {}))))
+
+(defn- slurp-file [f]
+  #?(:clj (when-let [f (io/file f)]
+            (when (.exists f)
+              (slurp f)))
+     :cljs (when (.existsSync fs f)
+             (str (.readFileSync fs f)))))
+
+(defn- read-env-file [f]
+  (when-let [content (slurp-file f)]
+    (into {} (for [[k v] (edn/read-string content)]
+               [(sanitize-key k) (sanitize-val k v)]))))
+
+(defn- warn-on-overwrite [ms]
+  (doseq [[k kvs] (group-by key (apply concat ms))
+          :let  [vs (map val kvs)]
+          :when (and (next kvs) (not= (first vs) (last vs)))]
+    (println "Warning: environ value" (first vs) "for key" k
+             "has been overwritten with" (last vs))))
+
+(defn- merge-env [& ms]
+  (warn-on-overwrite ms)
+  (apply merge ms))
+
+(defn read-env []
+  #?(:clj (merge-env
+           (read-env-file ".lein-env")
+           (read-env-file (io/resource ".boot-env"))
+           (read-system-env)
+           (read-system-props))
+     :cljs (if nodejs?
+             (merge-env
+              (read-env-file ".lein-env")
+              (read-system-env))
+             {})))


### PR DESCRIPTION
This means read-env needs to be public for graal native compilation to work.  I filed an issue to make it public via environ but have received no response.  I am not certain the #' access-private-var pathway will work correctly and as environ is very simple (and we should know exactly how it works) I simply moved it into config. 

Debatable but the actual technical risk is minimal as the code is trivial.